### PR TITLE
Parser 리팩토링 및 Log class 추가

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,17 +8,13 @@ CXX			:= c++
 CXXFLAGS	:= -std=c++98 -pedantic -Wall -Wextra -Werror
 RM			:= rm -rf
 
-ifdef PARSER_LOG
-	MACRO_NAME = PARSER_LOG
-else
-	MACRO_NAME = NONE
-endif
 
 # ===== Sources =====
 INCD			:=	-I ./include
 
 SRCS_DIR	:=	src
 SRCS_NAME	:=	main.cpp						\
+							Log.cpp							\
 							Scanner.cpp					\
 							Parser.cpp					\
 							Config.cpp					\
@@ -68,12 +64,14 @@ INDEX = 0
 	else \
 		echo -en "$(FG_TEXT)◼︎︎︎︎︎︎◼︎︎︎︎︎◼︎︎︎︎︎︎◼︎︎︎︎︎" ; \
 	fi
-	@$(CXX) $(CXXFLAGS) $(INCD) -c $< -o $@ -g -D $(MACRO_NAME)
+	@$(CXX) $(CXXFLAGS) $(INCD) -c $< -o $@ -g
 
 
 # ===== Custom =====
-.PHONY : test
+.PHONY : run test
 
-test :
-	@make PARSER_LOG=1 re
+run : all
+	@./$(NAME)
+
+test : all
 	@./$(NAME) ./config/test.conf

--- a/config/default.conf
+++ b/config/default.conf
@@ -8,7 +8,7 @@ server {
     }
 
     error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
+    location /50x.html {
         root   html;
     }
 }

--- a/include/Log.hpp
+++ b/include/Log.hpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 hyojekim. All rights reserved.
+
+#ifndef LOG_HPP_
+#define LOG_HPP_
+
+#include <fstream>
+#include <string>
+
+namespace ft {
+enum LogFlag { LOG_TITLE, LOG_FILE };
+
+const std::string getTimestamp(LogFlag flag = LOG_FILE);
+
+class Log {
+ public:
+  Log();
+  ~Log();
+
+  std::ofstream& getLogStream();
+  void           writeTimeLog(const std::string& log);
+  void           writeLog(const std::string& log);
+  void           writeEndl();
+
+ private:
+  std::ofstream log_file_;
+};
+
+static Log log;
+}  // namespace ft
+
+#endif  // LOG_HPP_

--- a/include/Parser.hpp
+++ b/include/Parser.hpp
@@ -55,11 +55,11 @@ class Parser {
   void initLocationParsingMap();
   void initCommonParsingMap();
 
-  ResultType parseServer(ConfigServer& server, size_t& idx);
-  ResultType parseLocation(ConfigLocation& location, size_t& idx);
-  void       fillDefaultConfigServer(ConfigServer& server);
-  void       fillDefaultConfigLocation(ConfigServer&               server,
-                                       ConfigServer::LocationType& locations);
+  void parseServer(ConfigServer& server, size_t& idx);
+  void parseLocation(ConfigLocation& location, size_t& idx);
+  void fillDefaultConfigServer(ConfigServer& server);
+  void fillDefaultConfigLocation(ConfigServer&               server,
+                                 ConfigServer::LocationType& locations);
 
   void parseServerName(ConfigServer& server, const TokensType& args);
   void parseListen(ConfigServer& server, const TokensType& args);
@@ -71,6 +71,23 @@ class Parser {
   void parseErrorPage(ConfigCommon& common, const TokensType& args);
   void parseIndex(ConfigCommon& common, const TokensType& args);
   void parseRoot(ConfigCommon& common, const TokensType& args);
+
+  bool isServerDirective(ServerParserFuncMapIterator& it_server,
+                         CommonParserFuncMapIterator& it_common,
+                         const std::string&           token);
+
+  bool isLocationDirective(LocationParserFuncMapIterator& it_location,
+                           CommonParserFuncMapIterator&   it_common,
+                           const std::string&             token);
+
+  void serverParserFunctionCall(ConfigServer& server, ConfigCommon& common,
+                                TokensType& args, const std::string& directive,
+                                const FunctionType type);
+
+  void locationParserFunctionCall(ConfigLocation& location,
+                                  ConfigCommon& common, TokensType& args,
+                                  const std::string& directive,
+                                  const FunctionType type);
 };
 
 #endif  // PARSER_HPP_

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -47,9 +47,8 @@ void Config::printServer(const ConfigServer& server) const {
   std::cout << GRN "  [server name]" END << std::endl;
   const ServerNameType server_name = server.getServerName();
   for (ServerNameType::const_iterator it = server_name.begin();
-       it != server_name.end(); ++it) {
+       it != server_name.end(); ++it)
     std::cout << "    " << *it << "\n";
-  }
   std::cout << std::endl;
 
   std::cout << GRN "  [listen]" END << std::endl;
@@ -72,9 +71,8 @@ void Config::printLocation(const ConfigLocation& location,
   std::cout << indent << YEL "  [limit_except]" END << std::endl;
   const LimitExceptType limit_except = location.getLimitExcept();
   for (LimitExceptType::const_iterator it = limit_except.begin();
-       it != limit_except.end(); ++it) {
+       it != limit_except.end(); ++it)
     std::cout << indent << "    " << *it << "\n";
-  }
   std::cout << std::endl;
 
   printCommon(location.getCommon(), indent + "  ", YEL);
@@ -93,17 +91,15 @@ void Config::printCommon(const ConfigCommon& common, const std::string& indent,
 
   std::cout << indent << color << "[index]" END << std::endl;
   const IndexType index = common.getIndex();
-  for (IndexType::const_iterator it = index.begin(); it != index.end(); ++it) {
+  for (IndexType::const_iterator it = index.begin(); it != index.end(); ++it)
     std::cout << indent << "  " << *it << "\n";
-  }
   std::cout << std::endl;
 
   std::cout << indent << color << "[error_page]" END << std::endl;
   const ErrorPageType error_page = common.getErrorPage();
   for (ErrorPageType::const_iterator it = error_page.begin();
-       it != error_page.end(); ++it) {
+       it != error_page.end(); ++it)
     std::cout << indent << "  " << it->first << " -> " << it->second << "\n";
-  }
   std::cout << std::endl;
 }
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -5,6 +5,7 @@
 
 #include <iostream>
 
+#include "Log.hpp"
 #include "color.hpp"
 
 Config::Config() : servers_() {}
@@ -34,73 +35,78 @@ Config::ListenListType Config::getAllListenList() const {
 }
 
 void Config::printConfig() const {
+  ft::log.writeTimeLog("[Config] --- Print config ---");
+
   int i = 0;
   for (ServersType::const_iterator server = servers_.begin();
        server != servers_.end(); ++server, ++i) {
-    std::cout << BGRN "📮 server [" << i << "]" END << std::endl;
+    ft::log.getLogStream() << BGRN "📮 server [" << i << "]" END << std::endl;
     printServer(*server);
-    std::cout << std::endl;
+    ft::log.writeEndl();
   }
 }
 
 void Config::printServer(const ConfigServer& server) const {
-  std::cout << GRN "  [server name]" END << std::endl;
+  ft::log.getLogStream() << GRN "  [server name]" END << std::endl;
   const ServerNameType server_name = server.getServerName();
   for (ServerNameType::const_iterator it = server_name.begin();
        it != server_name.end(); ++it)
-    std::cout << "    " << *it << "\n";
-  std::cout << std::endl;
+    ft::log.getLogStream() << "    " << *it << "\n";
+  ft::log.writeEndl();
 
-  std::cout << GRN "  [listen]" END << std::endl;
+  ft::log.writeLog(GRN "  [listen]" END);
   printListen(server.getListen(), "    ");
 
   printCommon(server.getCommon(), "  ", GRN);
-  std::cout << std::endl;
+  ft::log.writeEndl();
 
   const LocationType locations = server.getLocation();
   for (LocationType::const_iterator loc = locations.begin();
        loc != locations.end(); ++loc) {
-    std::cout << BYEL "  📂 location " << loc->first << END << std::endl;
+    ft::log.getLogStream() << BYEL "  📂 location " << loc->first << END
+                           << std::endl;
     printLocation(loc->second, "    ");
-    std::cout << std::endl;
+    ft::log.writeEndl();
   }
 }
 
 void Config::printLocation(const ConfigLocation& location,
                            const std::string&    indent) const {
-  std::cout << indent << YEL "  [limit_except]" END << std::endl;
+  ft::log.getLogStream() << indent << YEL "  [limit_except]" END << std::endl;
   const LimitExceptType limit_except = location.getLimitExcept();
   for (LimitExceptType::const_iterator it = limit_except.begin();
        it != limit_except.end(); ++it)
-    std::cout << indent << "    " << *it << "\n";
-  std::cout << std::endl;
+    ft::log.getLogStream() << indent << "    " << *it << "\n";
+  ft::log.writeEndl();
 
   printCommon(location.getCommon(), indent + "  ", YEL);
 }
 
 void Config::printCommon(const ConfigCommon& common, const std::string& indent,
                          const std::string& color) const {
-  std::cout << indent << color << "[autoindex] " END
-            << (common.getAutoindex() ? "on" : "off") << "\n"
-            << std::endl;
-  std::cout << indent << color << "[client_body_buffer_size] " END
-            << common.getClientBodyBufferSize() << "\n"
-            << std::endl;
-  std::cout << indent << color << "[root] " END << common.getRoot() << "\n"
-            << std::endl;
+  ft::log.getLogStream() << indent << color << "[autoindex] " END
+                         << (common.getAutoindex() ? "on" : "off") << "\n"
+                         << std::endl;
+  ft::log.getLogStream() << indent << color << "[client_body_buffer_size] " END
+                         << common.getClientBodyBufferSize() << "\n"
+                         << std::endl;
+  ft::log.getLogStream() << indent << color << "[root] " END << common.getRoot()
+                         << "\n"
+                         << std::endl;
 
-  std::cout << indent << color << "[index]" END << std::endl;
+  ft::log.getLogStream() << indent << color << "[index]" END << std::endl;
   const IndexType index = common.getIndex();
   for (IndexType::const_iterator it = index.begin(); it != index.end(); ++it)
-    std::cout << indent << "  " << *it << "\n";
-  std::cout << std::endl;
+    ft::log.getLogStream() << indent << "  " << *it << "\n";
+  ft::log.writeEndl();
 
-  std::cout << indent << color << "[error_page]" END << std::endl;
+  ft::log.getLogStream() << indent << color << "[error_page]" END << std::endl;
   const ErrorPageType error_page = common.getErrorPage();
   for (ErrorPageType::const_iterator it = error_page.begin();
        it != error_page.end(); ++it)
-    std::cout << indent << "  " << it->first << " -> " << it->second << "\n";
-  std::cout << std::endl;
+    ft::log.getLogStream() << indent << "  " << it->first << " -> "
+                           << it->second << "\n";
+  ft::log.writeEndl();
 }
 
 void Config::printListen(const Config::ListenListType& listen_list,
@@ -109,8 +115,8 @@ void Config::printListen(const Config::ListenListType& listen_list,
        it != listen_list.end(); ++it) {
     sockaddr_in addr;
     addr.sin_addr.s_addr = it->first;
-    std::cout << indent << inet_ntoa(addr.sin_addr) << ":" << it->second
-              << "\n";
+    ft::log.getLogStream() << indent << inet_ntoa(addr.sin_addr) << ":"
+                           << it->second << "\n";
   }
-  std::cout << std::endl;
+  ft::log.writeEndl();
 }

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -1,0 +1,51 @@
+#include "Log.hpp"
+
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+const std::string ft::getTimestamp(ft::LogFlag flag) {
+  time_t rawtime;
+  time(&rawtime);
+
+  struct tm* timeinfo;
+  timeinfo = localtime(&rawtime);
+
+  std::stringstream timestamp;
+  if (flag == ft::LOG_TITLE) {
+    timestamp << std::setfill('0') << std::setw(4) << timeinfo->tm_year + 1900
+              << std::setw(2) << timeinfo->tm_mon + 1 << std::setw(2)
+              << timeinfo->tm_mday << "_" << std::setw(2) << timeinfo->tm_hour
+              << std::setw(2) << timeinfo->tm_min << std::setw(2)
+              << timeinfo->tm_sec;
+  } else {
+    timestamp << "[" << std::setfill('0') << std::setw(4)
+              << timeinfo->tm_year + 1900 << "/" << std::setw(2)
+              << timeinfo->tm_mon + 1 << "/" << std::setw(2)
+              << timeinfo->tm_mday << " " << std::setw(2) << timeinfo->tm_hour
+              << ":" << std::setw(2) << timeinfo->tm_min << ":" << std::setw(2)
+              << timeinfo->tm_sec << "] ";
+  }
+
+  return timestamp.str();
+}
+
+ft::Log::Log() {
+  log_file_.open(getTimestamp(ft::LOG_TITLE) + ".log",
+                 std::ofstream::out | std::ofstream::app);
+}
+
+ft::Log::~Log() {}
+
+std::ofstream& ft::Log::getLogStream() { return log_file_; }
+
+void ft::Log::writeTimeLog(const std::string& log) {
+  log_file_ << getTimestamp() << log << std::endl;
+}
+
+void ft::Log::writeLog(const std::string& log) {
+  log_file_ << log << std::endl;
+}
+
+void ft::Log::writeEndl() { log_file_ << std::endl; }

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -2,10 +2,16 @@
 
 #include <iostream>
 
+#include "Log.hpp"
 #include "color.hpp"
 
 Parser::Parser(const std::string& filename) : tokens_() {
+  ft::log.writeTimeLog("[Parser] --- Start to parsing ---");
+  ft::log.writeTimeLog("Tokenizeing...");
+
   Scanner::readFile(tokens_, filename);
+  ft::log.getLogStream() << tokens_ << std::endl;
+
   initServerParsingMap();
   initLocationParsingMap();
   initCommonParsingMap();
@@ -14,9 +20,7 @@ Parser::Parser(const std::string& filename) : tokens_() {
 Parser::~Parser() {}
 
 void Parser::parse(Config& config) {
-#if defined(PARSER_LOG)
-  std::cout << tokens_ << std::endl;
-#endif
+  ft::log.writeTimeLog("Parsing...");
 
   for (size_t i = 0; i < tokens_.size(); ++i) {
     if (tokens_[i] == "server") {
@@ -31,6 +35,8 @@ void Parser::parse(Config& config) {
       throw std::invalid_argument("Config: Server block is not found.");
     }
   }
+
+  ft::log.writeTimeLog("[Parser] --- Success to config parsing ---");
 }
 
 void Parser::initServerParsingMap() {
@@ -52,6 +58,8 @@ void Parser::initCommonParsingMap() {
 }
 
 void Parser::parseServer(ConfigServer& server, size_t& idx) {
+  ft::log.writeLog(GRN "--- parseServer ---" END);
+
   ConfigServer::LocationType locations;
   ConfigCommon               common;
 
@@ -60,10 +68,6 @@ void Parser::parseServer(ConfigServer& server, size_t& idx) {
   FunctionType                type;
   std::string                 directive;
   TokensType                  args;
-
-#if defined(PARSER_LOG)
-  std::cout << "\n" GRN "--- parseServer ---" END << std::endl;
-#endif
 
   for (; idx < tokens_.size() && tokens_[idx] != "}"; ++idx) {
     if (isServerDirective(it_server, it_common, tokens_[idx])) {
@@ -102,17 +106,17 @@ void Parser::parseServer(ConfigServer& server, size_t& idx) {
   if (tokens_[idx] != "}")
     throw std::invalid_argument("Config: Server block must end with '}'");
 
-#if defined(PARSER_LOG)
-  std::cout << GRN "-------------------" END "\n" << std::endl;
-#endif
-
   server.setCommon(common);
   fillDefaultConfigServer(server);
   fillDefaultConfigLocation(server, locations);
   server.setLocation(locations);
+
+  ft::log.writeLog(GRN "-------------------" END);
 }
 
 void Parser::parseLocation(ConfigLocation& location, size_t& idx) {
+  ft::log.writeLog(YEL "  --- parseLocation ---" END);
+
   ConfigCommon common;
 
   LocationParserFuncMapIterator it_location;
@@ -120,10 +124,6 @@ void Parser::parseLocation(ConfigLocation& location, size_t& idx) {
   FunctionType                  type;
   std::string                   directive;
   TokensType                    args;
-
-#if defined(PARSER_LOG)
-  std::cout << "\n  " YEL "--- parseLocation ---" END << std::endl;
-#endif
 
   for (; idx < tokens_.size() && tokens_[idx] != "}"; ++idx) {
     if (isLocationDirective(it_location, it_common, tokens_[idx])) {
@@ -143,11 +143,9 @@ void Parser::parseLocation(ConfigLocation& location, size_t& idx) {
   if (tokens_[idx] != "}")
     throw std::invalid_argument("Config: Location block must end with '}'");
 
-#if defined(PARSER_LOG)
-  std::cout << YEL "  --------------------- " END "\n" << std::endl;
-#endif
-
   location.setCommon(common);
+
+  ft::log.writeLog(YEL "  --------------------- " END);
 }
 
 void Parser::fillDefaultConfigServer(ConfigServer& server) {
@@ -338,9 +336,8 @@ void Parser::serverParserFunctionCall(ConfigServer&       server,
                                       Parser::TokensType& args,
                                       const std::string&  directive,
                                       const FunctionType  type) {
-#if defined(PARSER_LOG)
-  std::cout << GRN "[" << directive << "] " END << args << std::endl;
-#endif
+  ft::log.getLogStream() << GRN "[" << directive << "] " END << args
+                         << std::endl;
 
   if (args.back() != ";")
     throw std::invalid_argument("Config: Directive must end with ';'");
@@ -358,9 +355,8 @@ void Parser::locationParserFunctionCall(ConfigLocation&     location,
                                         Parser::TokensType& args,
                                         const std::string&  directive,
                                         const FunctionType  type) {
-#if defined(PARSER_LOG)
-  std::cout << YEL "  [" << directive << "] " END << args << std::endl;
-#endif
+  ft::log.getLogStream() << YEL "  [" << directive << "] " END << args
+                         << std::endl;
 
   if (args.back() != ";")
     throw std::invalid_argument("Config: Directive must end with ';'");

--- a/src/Scanner.cpp
+++ b/src/Scanner.cpp
@@ -56,8 +56,9 @@ void Scanner::checkMetaCharacter(Scanner::TokensType& tokens,
     if (token != "")
       tokens.push_back(token);
     tokens.push_back(";");
-  } else
+  } else {
     tokens.push_back(str);
+  }
 }
 
 std::ostream& operator<<(std::ostream& os, const Scanner::TokensType& tokens) {

--- a/src/Webserv.cpp
+++ b/src/Webserv.cpp
@@ -41,7 +41,7 @@ void Webserv::runWebserv() {
   while (1) {
     fd_set         read_fds;
     fd_set         write_fds;
-    struct timeval timeout = {1, 0};  // tv_sec = 5, tv_usec = 0
+    struct timeval timeout = {1, 0};  // tv_sec = 1, tv_usec = 0
     int            state = kTimeOut;
 
     std::string loading_dot[3] = {".  ", ".. ", "..."};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,13 +21,10 @@ int main(int argc, char* argv[]) {
   try {
     Parser parser(filename);
     parser.parse(config);
-
-#if defined(PARSER_LOG)
     config.printConfig();
-#endif
 
   } catch (std::exception& e) {
-    std::cout << RED << e.what() << END << std::endl;
+    std::cerr << RED << e.what() << END << std::endl;
     return 1;
   }
 


### PR DESCRIPTION
### 개요
1. Parser class 리팩토링
    - 중복되는 부분 함수화
    - if문 중괄호 명시 통일화
<br>

2. Log class 추가
    - 기존: 표준출력 + -D macro 방식으로 출력유무 결정
    - 변경: 프로그램 시점 기준으로 생성된 로그파일에 진행사항 저장
    - 사용법
    ```c++
    std::ofstream& getLogStream();
    void           writeTimeLog(const std::string& log);
    void           writeLog(const std::string& log);
    void           writeEndl();
    ````
    1) `ft::getLogStream() << "문자열" << std::endl;`: 문자열 그대로 저장
    2) `ft::log.writeTimeLog("문자열");`: [타임스탬프] 문자열
    3) `ft::log.writeLog("문자열")`: 문자열 그대로 저장
    4) `ft::log.writeEndl();`: 개행만 삽입하고 싶을 때
---
- closes #10 
- closes #11