### PR TITLE
conf 파일 directive 추가

### DIFF
--- a/config/test.conf
+++ b/config/test.conf
@@ -1,31 +1,41 @@
 server {
-    listen localhost:8080;
-    server_name localhost;
+    # listen localhost:8080;
+    # server_name localhost;
 
-    error_page 500 502 503 504 /50x.html;
+    # error_page 500 502 503 504 /50x.html;
     
     
-    client_body_buffer_size 4096;
+    # client_body_buffer_size 4096;
 
 
-    autoindex on;
+    # autoindex on;
 
-    location / {
-        root ./www;
-        limit_except GET;
-        index index.html;
-        client_body_buffer_size 1024;
-        error_page 404 /404.html;
+    # location / {
+    #     root ./www;
+    #     limit_except GET;
+    #     index index.html;
+    #     client_body_buffer_size 1024;
+    #     error_page 404 /404.html;
+    # }
+
+    # location /test {
+    #     root ./www/test;
+    #     autoindex on;
+    #     index test.html;
+    # }
+
+    location /intra {
+        return 301 https://profile.intra.42.fr/;
     }
 
-    location /test {
-        root ./www/test;
-        autoindex on;
-        index test.html;
+    location /cgi {
+        root ./www/cgi;
+        limit_except GET POST;
+        cgi .bla cgi_tester;
     }
 }
 
-server {
-    server_name show_default;
-    listen      localhost;
-}
+# server {
+#     server_name show_default;
+#     listen      localhost;
+# }

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -16,6 +16,8 @@ class Config {
   typedef ConfigServer::LocationType                LocationType;
   typedef ConfigServer::IndexType                   IndexType;
   typedef ConfigServer::ErrorPageType               ErrorPageType;
+  typedef ConfigServer::ReturnType                  ReturnType;
+  typedef ConfigLocation::CgiType                   CgiType;
   typedef ConfigLocation::LimitExceptType           LimitExceptType;
   typedef std::map<ListenType, const ConfigServer*> ConfigFinderType;
 

--- a/include/ConfigCommon.hpp
+++ b/include/ConfigCommon.hpp
@@ -17,10 +17,13 @@ class ConfigCommon {
   typedef std::string                            ErrorUriType;
   typedef std::pair<ErrorCodeType, ErrorUriType> ErrorPairType;
   typedef std::map<ErrorPairType::first_type, ErrorPairType::second_type>
-                                     ErrorPageType;
-  typedef std::string                IndexFileType;
-  typedef std::vector<IndexFileType> IndexType;
-  typedef std::string                RootType;
+                                                   ErrorPageType;
+  typedef std::string                              IndexFileType;
+  typedef std::vector<IndexFileType>               IndexType;
+  typedef unsigned int                             ReturnCodeType;
+  typedef std::string                              ReturnUrlType;
+  typedef std::pair<ReturnCodeType, ReturnUrlType> ReturnType;
+  typedef std::string                              RootType;
 
   ConfigCommon();
   ConfigCommon(const ConfigCommon& other);
@@ -31,6 +34,7 @@ class ConfigCommon {
   const ClientBodyBufferSizeType& getClientBodyBufferSize() const;
   const ErrorPageType&            getErrorPage() const;
   const IndexType&                getIndex() const;
+  const ReturnType&               getReturn() const;
   const RootType&                 getRoot() const;
 
   void setAutoindex(const AutoindexType& value);
@@ -38,6 +42,7 @@ class ConfigCommon {
   void addErrorPage(const ErrorPairType& value);
   void setIndex(const IndexType& index);
   void addIndex(const IndexFileType& value);
+  void setReturn(const ReturnType& value);
   void setRoot(const RootType& value);
 
  private:
@@ -48,6 +53,7 @@ class ConfigCommon {
   ClientBodyBufferSizeType client_body_buffer_size_;
   ErrorPageType            error_page_;
   IndexType                index_;
+  ReturnType               return_;
   RootType                 root_;
 };
 

--- a/include/ConfigLocation.hpp
+++ b/include/ConfigLocation.hpp
@@ -9,9 +9,11 @@
 
 class ConfigLocation {
  public:
-  typedef std::string                      MethodType;
+  typedef std::string                         MethodType;
+  typedef std::pair<std::string, std::string> CgiPairType;
+  typedef std::map<CgiPairType::first_type, CgiPairType::second_type> CgiType;
+  typedef ConfigCommon                                                Common;
   typedef std::set<MethodType>             LimitExceptType;
-  typedef ConfigCommon                     Common;
   typedef Common::AutoindexType            AutoindexType;
   typedef Common::ClientBodyBufferSizeType ClientBodyBufferSizeType;
   typedef Common::ErrorCodeType            ErrorCodeType;
@@ -20,14 +22,17 @@ class ConfigLocation {
   typedef Common::ErrorPageType            ErrorPageType;
   typedef Common::IndexFileType            IndexFileType;
   typedef Common::IndexType                IndexType;
+  typedef Common::ReturnCodeType           ReturnCodeType;
+  typedef Common::ReturnUrlType            ReturnUrlType;
+  typedef Common::ReturnType               ReturnType;
   typedef Common::RootType                 RootType;
-  // typedef something cgi
 
   ConfigLocation();
   ConfigLocation(const ConfigLocation& other);
   ~ConfigLocation();
   ConfigLocation& operator=(const ConfigLocation& other);
 
+  const CgiType&         getCgi() const;
   const LimitExceptType& getLimitExcept() const;
   const Common&          getCommon() const;
 
@@ -35,8 +40,10 @@ class ConfigLocation {
   const ClientBodyBufferSizeType& getClientBodyBufferSize() const;
   const ErrorPageType&            getErrorPage() const;
   const IndexType&                getIndex() const;
+  const ReturnType&               getReturn() const;
   const RootType&                 getRoot() const;
 
+  void addCgi(const CgiPairType& value);
   void addLimitExcept(const MethodType& value);
   void setCommon(const Common& common);
 
@@ -45,12 +52,14 @@ class ConfigLocation {
   void addErrorPage(const ErrorPairType& value);
   void setIndex(const IndexType& index);
   void addIndex(const IndexFileType& value);
+  void setReturn(const ReturnType& value);
   void setRoot(const RootType& value);
 
   bool isInMethodSet(const MethodType& method) const;
 
  private:
   LimitExceptType method_set_;
+  CgiType         cgi_;
   LimitExceptType limit_except_;
   Common          common_config_;
 

--- a/include/ConfigServer.hpp
+++ b/include/ConfigServer.hpp
@@ -24,6 +24,9 @@ class ConfigServer {
   typedef Common::ErrorPageType            ErrorPageType;
   typedef Common::IndexFileType            IndexFileType;
   typedef Common::IndexType                IndexType;
+  typedef Common::ReturnCodeType           ReturnCodeType;
+  typedef Common::ReturnUrlType            ReturnUrlType;
+  typedef Common::ReturnType               ReturnType;
   typedef Common::RootType                 RootType;
 
   ConfigServer();
@@ -40,6 +43,7 @@ class ConfigServer {
   const ClientBodyBufferSizeType& getClientBodyBufferSize() const;
   const ErrorPageType&            getErrorPage() const;
   const IndexType&                getIndex() const;
+  const ReturnType&               getReturn() const;
   const RootType&                 getRoot() const;
 
   void setServerName(const ServerNameType& server_name);
@@ -55,6 +59,7 @@ class ConfigServer {
   void setClientBodyBufferSize(const ClientBodyBufferSizeType& value);
   void addErrorPage(const ErrorPairType& value);
   void addIndex(const IndexFileType& value);
+  void setReturn(const ReturnType& value);
   void setRoot(const RootType& value);
 
  private:

--- a/include/Parser.hpp
+++ b/include/Parser.hpp
@@ -64,12 +64,14 @@ class Parser {
   void parseServerName(ConfigServer& server, const TokensType& args);
   void parseListen(ConfigServer& server, const TokensType& args);
 
+  void parseCgi(ConfigLocation& location, const TokensType& args);
   void parseLimitExcept(ConfigLocation& location, const TokensType& args);
 
   void parseAutoindex(ConfigCommon& common, const TokensType& args);
   void parseClientBodyBufferSize(ConfigCommon& common, const TokensType& args);
   void parseErrorPage(ConfigCommon& common, const TokensType& args);
   void parseIndex(ConfigCommon& common, const TokensType& args);
+  void parseReturn(ConfigCommon& common, const TokensType& args);
   void parseRoot(ConfigCommon& common, const TokensType& args);
 
   bool isServerDirective(ServerParserFuncMapIterator& it_server,

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -88,6 +88,13 @@ void Config::printServer(const ConfigServer& server) {
 
 void Config::printLocation(const ConfigLocation& location,
                            const std::string&    indent) {
+  ft::log.getLogStream() << indent << YEL "  [cgi]" END << std::endl;
+  const CgiType cgi = location.getCgi();
+  for (CgiType::const_iterator it = cgi.begin(); it != cgi.end(); ++it)
+    ft::log.getLogStream() << indent << "    " << it->first << " " << it->second
+                           << "\n";
+  ft::log.writeEndl();
+
   ft::log.getLogStream() << indent << YEL "  [limit_except]" END << std::endl;
   const LimitExceptType limit_except = location.getLimitExcept();
   for (LimitExceptType::const_iterator it = limit_except.begin();
@@ -107,6 +114,12 @@ void Config::printCommon(const ConfigCommon& common, const std::string& indent,
                          << common.getClientBodyBufferSize() << "\n"
                          << std::endl;
   ft::log.getLogStream() << indent << color << "[root] " END << common.getRoot()
+                         << "\n"
+                         << std::endl;
+
+  const ReturnType return_pair = common.getReturn();
+  ft::log.getLogStream() << indent << color << "[return] " END
+                         << return_pair.first << " " << return_pair.second
                          << "\n"
                          << std::endl;
 

--- a/src/ConfigCommon.cpp
+++ b/src/ConfigCommon.cpp
@@ -5,6 +5,7 @@ ConfigCommon::ConfigCommon()
       client_body_buffer_size_(kDefaultClientBodyBufferSize),
       error_page_(),
       index_(),
+      return_(),
       root_("") {}
 
 ConfigCommon::ConfigCommon(const ConfigCommon& other)
@@ -12,6 +13,7 @@ ConfigCommon::ConfigCommon(const ConfigCommon& other)
       client_body_buffer_size_(other.client_body_buffer_size_),
       error_page_(other.error_page_),
       index_(other.index_),
+      return_(other.return_),
       root_(other.root_) {}
 
 ConfigCommon::~ConfigCommon() {}
@@ -21,6 +23,7 @@ ConfigCommon& ConfigCommon::operator=(const ConfigCommon& other) {
   client_body_buffer_size_ = other.client_body_buffer_size_;
   error_page_ = other.error_page_;
   index_ = other.index_;
+  return_ = other.return_;
   root_ = other.root_;
   return *this;
 }
@@ -39,6 +42,10 @@ const ConfigCommon::ErrorPageType& ConfigCommon::getErrorPage() const {
 }
 
 const ConfigCommon::IndexType& ConfigCommon::getIndex() const { return index_; }
+
+const ConfigCommon::ReturnType& ConfigCommon::getReturn() const {
+  return return_;
+}
 
 const ConfigCommon::RootType& ConfigCommon::getRoot() const { return root_; }
 
@@ -61,6 +68,10 @@ void ConfigCommon::setIndex(const ConfigCommon::IndexType& index) {
 
 void ConfigCommon::addIndex(const ConfigCommon::IndexFileType& value) {
   index_.push_back(value);
+}
+
+void ConfigCommon::setReturn(const ConfigCommon::ReturnType& value) {
+  return_ = value;
 }
 
 void ConfigCommon::setRoot(const ConfigCommon::RootType& value) {

--- a/src/ConfigLocation.cpp
+++ b/src/ConfigLocation.cpp
@@ -1,12 +1,13 @@
 #include "ConfigLocation.hpp"
 
 ConfigLocation::ConfigLocation()
-    : method_set_(), limit_except_(), common_config_() {
+    : method_set_(), cgi_(), limit_except_(), common_config_() {
   initMethodSet();
 }
 
 ConfigLocation::ConfigLocation(const ConfigLocation& other)
     : method_set_(other.method_set_),
+      cgi_(other.cgi_),
       limit_except_(other.limit_except_),
       common_config_(other.common_config_) {}
 
@@ -14,10 +15,13 @@ ConfigLocation::~ConfigLocation() {}
 
 ConfigLocation& ConfigLocation::operator=(const ConfigLocation& other) {
   method_set_ = other.method_set_;
+  cgi_ = other.cgi_;
   limit_except_ = other.limit_except_;
   common_config_ = other.common_config_;
   return *this;
 }
+
+const ConfigLocation::CgiType& ConfigLocation::getCgi() const { return cgi_; }
 
 const ConfigLocation::LimitExceptType& ConfigLocation::getLimitExcept() const {
   return limit_except_;
@@ -44,8 +48,16 @@ const ConfigLocation::IndexType& ConfigLocation::getIndex() const {
   return common_config_.getIndex();
 }
 
+const ConfigLocation::ReturnType& ConfigLocation::getReturn() const {
+  return common_config_.getReturn();
+}
+
 const ConfigLocation::RootType& ConfigLocation::getRoot() const {
   return common_config_.getRoot();
+}
+
+void ConfigLocation::addCgi(const ConfigLocation::CgiPairType& value) {
+  cgi_.insert(value);
 }
 
 void ConfigLocation::addLimitExcept(const ConfigLocation::MethodType& value) {
@@ -75,6 +87,10 @@ void ConfigLocation::setIndex(const ConfigLocation::IndexType& index) {
 
 void ConfigLocation::addIndex(const ConfigLocation::IndexFileType& value) {
   common_config_.addIndex(value);
+}
+
+void ConfigLocation::setReturn(const ConfigLocation::ReturnType& value) {
+  common_config_.setReturn(value);
 }
 
 void ConfigLocation::setRoot(const ConfigLocation::RootType& value) {

--- a/src/ConfigServer.cpp
+++ b/src/ConfigServer.cpp
@@ -54,6 +54,10 @@ const ConfigServer::IndexType& ConfigServer::getIndex() const {
   return common_config_.getIndex();
 }
 
+const ConfigServer::ReturnType& ConfigServer::getReturn() const {
+  return common_config_.getReturn();
+}
+
 const ConfigServer::RootType& ConfigServer::getRoot() const {
   return common_config_.getRoot();
 }
@@ -109,6 +113,10 @@ void ConfigServer::addErrorPage(const ConfigServer::ErrorPairType& value) {
 
 void ConfigServer::addIndex(const ConfigServer::IndexFileType& value) {
   common_config_.addIndex(value);
+}
+
+void ConfigServer::setReturn(const ConfigServer::ReturnType& value) {
+  common_config_.setReturn(value);
 }
 
 void ConfigServer::setRoot(const ConfigServer::RootType& value) {

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -45,6 +45,7 @@ void Parser::initServerParsingMap() {
 }
 
 void Parser::initLocationParsingMap() {
+  location_parsing_map_["cgi"] = &Parser::parseCgi;
   location_parsing_map_["limit_except"] = &Parser::parseLimitExcept;
 }
 
@@ -54,6 +55,7 @@ void Parser::initCommonParsingMap() {
       &Parser::parseClientBodyBufferSize;
   common_parsing_map_["error_page"] = &Parser::parseErrorPage;
   common_parsing_map_["index"] = &Parser::parseIndex;
+  common_parsing_map_["return"] = &Parser::parseReturn;
   common_parsing_map_["root"] = &Parser::parseRoot;
 }
 
@@ -239,6 +241,15 @@ void Parser::parseListen(ConfigServer& server, const Parser::TokensType& args) {
   server.addListen(std::make_pair(addr, port));
 }
 
+void Parser::parseCgi(ConfigLocation&           location,
+                      const Parser::TokensType& args) {
+  if (args.size() != 3)
+    throw std::invalid_argument(
+        "Config: cgi: Invalid arguments."
+        "\nUsage: cgi extenstion cgi_program_path");
+  location.addCgi(std::make_pair(args[0], args[1]));
+}
+
 void Parser::parseLimitExcept(ConfigLocation&           location,
                               const Parser::TokensType& args) {
   if (args.size() < 2)
@@ -297,6 +308,17 @@ void Parser::parseIndex(ConfigCommon& common, const Parser::TokensType& args) {
 
   for (size_t i = 0; i < args.size() - 1; ++i)
     common.addIndex(args[i]);
+}
+
+void Parser::parseReturn(ConfigCommon& common, const Parser::TokensType& args) {
+  if (args.size() != 3)
+    throw std::invalid_argument(
+        "Config: return: Invalid arguments."
+        "\nUsage: return code url");
+
+  if (!isDigits(args[0]))
+    throw std::invalid_argument("Config: return: Invalid code.");
+  common.setReturn(std::make_pair(atoi(args[0].c_str()), args[1]));
 }
 
 void Parser::parseRoot(ConfigCommon& common, const Parser::TokensType& args) {


### PR DESCRIPTION
### 개요
1. return
    - `return code url` 형식
    - 해당 directive가 있으면 code와 함께 url로 redirect

2. cgi
    - `cgi extension path` 형식
    - extension으로 지정된 파일에 접근했을 때 실행할 cgi 프로그램 경로를 명시
---
- closes #13 