### PR TITLE
Processor에 필요한 ConfigServer 전달 방식 수정

### DIFF
--- a/config/find_server.conf
+++ b/config/find_server.conf
@@ -1,0 +1,24 @@
+    server {
+        listen 4242;
+        server_name localhost;
+    }
+
+    server {
+        listen 4242;
+        server_name hostA hostB hostC;
+    }
+
+    server {
+        listen 4242;
+        server_name host1 host2 host3;
+    }
+    
+    server {
+        listen 8080;
+        server_name hospital;
+    }
+
+    server {
+        listen       0.0.0.0:8080;
+        server_name  localhost;
+    }

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -9,17 +9,16 @@
 
 class Config {
  public:
-  typedef std::vector<ConfigServer>                 ServersType;
-  typedef ConfigServer::ServerNameType              ServerNameType;
-  typedef ConfigServer::ListenType                  ListenType;
-  typedef ConfigServer::ListenListType              ListenListType;
-  typedef ConfigServer::LocationType                LocationType;
-  typedef ConfigServer::IndexType                   IndexType;
-  typedef ConfigServer::ErrorPageType               ErrorPageType;
-  typedef ConfigServer::ReturnType                  ReturnType;
-  typedef ConfigLocation::CgiType                   CgiType;
-  typedef ConfigLocation::LimitExceptType           LimitExceptType;
-  typedef std::map<ListenType, const ConfigServer*> ConfigFinderType;
+  typedef std::vector<ConfigServer>       ServersType;
+  typedef ConfigServer::ServerNamesType   ServerNamesType;
+  typedef ConfigServer::ListenType        ListenType;
+  typedef ConfigServer::ListenListType    ListenListType;
+  typedef ConfigServer::LocationType      LocationType;
+  typedef ConfigServer::IndexType         IndexType;
+  typedef ConfigServer::ErrorPageType     ErrorPageType;
+  typedef ConfigServer::ReturnType        ReturnType;
+  typedef ConfigLocation::CgiType         CgiType;
+  typedef ConfigLocation::LimitExceptType LimitExceptType;
 
   static void printServer(const ConfigServer& server);
   static void printLocation(const ConfigLocation& location,
@@ -35,7 +34,6 @@ class Config {
   const ServersType& getServers() const;
   void               addServers(const ConfigServer& server);
   ListenListType     getAllListenList() const;
-  ConfigFinderType   getConfigFinder() const;
 
   void printConfig() const;
 

--- a/include/ConfigServer.hpp
+++ b/include/ConfigServer.hpp
@@ -7,7 +7,7 @@
 
 class ConfigServer {
  public:
-  typedef std::vector<std::string>               ServerNameType;
+  typedef std::vector<std::string>               ServerNamesType;
   typedef std::uint32_t                          AddressType;
   typedef std::uint16_t                          PortType;
   typedef std::pair<AddressType, PortType>       ListenType;
@@ -34,10 +34,10 @@ class ConfigServer {
   ~ConfigServer();
   ConfigServer& operator=(const ConfigServer& other);
 
-  const ServerNameType& getServerName() const;
-  const ListenListType& getListen() const;
-  const LocationType&   getLocation() const;
-  const Common&         getCommon() const;
+  const ServerNamesType& getServerName() const;
+  const ListenListType&  getListen() const;
+  const LocationType&    getLocation() const;
+  const Common&          getCommon() const;
 
   const AutoindexType&            getAutoindex() const;
   const ClientBodyBufferSizeType& getClientBodyBufferSize() const;
@@ -46,7 +46,7 @@ class ConfigServer {
   const ReturnType&               getReturn() const;
   const RootType&                 getRoot() const;
 
-  void setServerName(const ServerNameType& server_name);
+  void setServerName(const ServerNamesType& server_name);
   void addServerName(const std::string& value);
   void setListen(const ListenListType& listen);
   void addListen(const ListenType& value);
@@ -63,10 +63,10 @@ class ConfigServer {
   void setRoot(const RootType& value);
 
  private:
-  ServerNameType server_name_;
-  ListenListType listen_;
-  LocationType   location_;
-  Common         common_config_;
+  ServerNamesType server_name_;
+  ListenListType  listen_;
+  LocationType    location_;
+  Common          common_config_;
 };
 
 #endif  // CONFIGSERVER_HPP_

--- a/include/Processor.hpp
+++ b/include/Processor.hpp
@@ -5,13 +5,18 @@
 #include <string>
 #include <vector>
 
-#include "ConfigServer.hpp"
+#include "Config.hpp"
 #include "Request.hpp"
 
 class Processor {
  public:
   typedef void (Processor::*MethodFuncType)();
   typedef std::map<Method, MethodFuncType> MethodFuncMapType;
+
+  typedef Config::ServersType      ServersType;
+  typedef Config::ServerNamesType  ServerNamesType;
+  typedef Config::ListenListType   ListenListType;
+  typedef ConfigServer::ListenType ListenType;
 
   typedef Request::MessageType      MessageType;
   typedef Request::StatusCodeType   StatusCodeType;
@@ -33,7 +38,7 @@ class Processor {
   void setStatusCode(const StatusCodeType& status_code);
   void setRequest(const Request& request);
 
-  void process();
+  void process(const Config& total_config, const ListenType& listen);
 
   int         parseRequest(MessageType request_message);
   void        printResponse();
@@ -48,13 +53,17 @@ class Processor {
 
  private:
   MethodFuncMapType method_func_map_;
-  ConfigServer      config_;
-  FdType            fd_;
-  StatusCodeType    status_code_;
-  Request           request_;
+
+  ConfigServer   config_;
+  FdType         fd_;
+  StatusCodeType status_code_;
+  Request        request_;
   // Response       response_;
 
   void initMethodFuncMap();
+
+  ConfigServer getConfigServerForRequest(
+      const Config& total_config, const ConfigServer::ListenType& listen);
 };
 
 #endif

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -22,7 +22,7 @@ class RequestHeader {
   typedef std::string                              HeaderValueType;
   typedef std::map<HeaderKeyType, HeaderValueType> HeaderMapType;
 
-  typedef std::string   AddressType;
+  typedef std::string   ServerNameType;
   typedef std::uint16_t PortType;
   typedef std::size_t   ContentLengthType;
   typedef int           ContentTypeType;
@@ -36,7 +36,7 @@ class RequestHeader {
 
   const HeaderMapType&     getHeaderMap() const;
   const HeaderValueType&   getHeader(const HeaderKeyType& key) const;
-  const AddressType&       getAddress() const;
+  const ServerNameType&    getServerName() const;
   const PortType&          getPort() const;
   const ContentLengthType& getContentLength() const;
   const ContentTypeType&   getContentType() const;
@@ -45,7 +45,7 @@ class RequestHeader {
   void setHeaderMap(const HeaderMapType& header_map, const Method& method);
   void setHeader(const HeaderKeyType& key, const HeaderValueType& value,
                  const Method& method);
-  void setAddress(const AddressType& address);
+  void setServerName(const ServerNameType& server_name);
   void setPort(const PortType& port);
   void setContentLength(const ContentLengthType& content_length);
   void setContentType(const ContentTypeType& content_type);
@@ -62,7 +62,7 @@ class RequestHeader {
   void initParseFuncMap();
 
   HeaderMapType     header_map_;
-  AddressType       address_;
+  ServerNameType    server_name_;
   PortType          port_;
   ContentLengthType content_length_;
   ContentTypeType   content_type_;
@@ -101,6 +101,8 @@ class Request {
   const BodyType&        getBody() const;
   const State&           getState() const;
   const Level&           getLevel() const;
+
+  const RequestHeader::ServerNameType& getServerName() const;
 
   void setRequestMessage(const MessageType& request_message);
   void setMethod(const Method& method);

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -31,10 +31,12 @@ class Server {
   const ConfigServer::PortType& getPort() const;
 
   void      initServer();
-  FdType    acceptClient(const ConfigServer& config);
+  FdType    acceptClient();
   RecvState receiveData(FdType client_socket);
   SendState sendData(FdType client_socket);
   void      closeClient(FdType client_socket);
+
+  void process(FdType client_socket, const Config& total_config);
 
  private:
   static const int kBacklog = 1024;

--- a/include/Utilities.hpp
+++ b/include/Utilities.hpp
@@ -25,6 +25,8 @@ std::string getUntilDelimiter(const std::string& str,
 std::string splitUntilDelimiter(std::string& str, std::string delimiter);
 std::vector<std::string> splitByString(std::string str, std::string delimiter);
 
+bool isDigits(const std::string& str);
+
 }  // namespace ft
 
 #endif

--- a/include/Webserv.hpp
+++ b/include/Webserv.hpp
@@ -11,21 +11,20 @@ class Webserv {
   typedef std::map<FdType, Server>  FdServerMapType;
   typedef std::map<FdType, Server*> ConnectSocketType;
   typedef std::vector<FdType>       ReadyType;
-  typedef Config::ConfigFinderType  ConfigFinderType;
 
-  Webserv();
+  Webserv(const Config& config);
   ~Webserv();
 
-  void initWebserv(const Config& config);
+  void initWebserv();
   void runWebserv();
 
  private:
   static const int kTimeOut = 0;
   static const int kError = -1;
 
+  const Config&     config_;
   FdType            max_fd_;
   fd_set            fd_set_;
-  ConfigFinderType  config_finder_;
   FdServerMapType   server_map_;
   ConnectSocketType connect_socket_;
   ReadyType         ready_to_write_;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -34,22 +34,6 @@ Config::ListenListType Config::getAllListenList() const {
   return all_listen_list;
 }
 
-Config::ConfigFinderType Config::getConfigFinder() const {
-  ConfigFinderType     config_finder;
-  std::set<ListenType> unique_list;
-
-  for (ServersType::const_iterator config = servers_.begin();
-       config != servers_.end(); ++config) {
-    const ListenListType& listen_list = config->getListen();
-    for (ListenListType::const_iterator listen = listen_list.begin();
-         listen != listen_list.end(); ++listen) {
-      if ((unique_list.insert(*listen)).second)
-        config_finder.insert(std::make_pair(*listen, &(*config)));
-    }
-  }
-  return config_finder;
-}
-
 void Config::printConfig() const {
   ft::log.writeTimeLog("[Config] --- Print config after parsing ---");
 
@@ -64,8 +48,8 @@ void Config::printConfig() const {
 
 void Config::printServer(const ConfigServer& server) {
   ft::log.getLogStream() << GRN "  [server name]" END << std::endl;
-  const ServerNameType server_name = server.getServerName();
-  for (ServerNameType::const_iterator it = server_name.begin();
+  const ServerNamesType server_name = server.getServerName();
+  for (ServerNamesType::const_iterator it = server_name.begin();
        it != server_name.end(); ++it)
     ft::log.getLogStream() << "    " << *it << "\n";
   ft::log.writeEndl();

--- a/src/ConfigServer.cpp
+++ b/src/ConfigServer.cpp
@@ -21,7 +21,7 @@ ConfigServer& ConfigServer::operator=(const ConfigServer& other) {
   return *this;
 }
 
-const ConfigServer::ServerNameType& ConfigServer::getServerName() const {
+const ConfigServer::ServerNamesType& ConfigServer::getServerName() const {
   return server_name_;
 }
 
@@ -63,7 +63,7 @@ const ConfigServer::RootType& ConfigServer::getRoot() const {
 }
 
 void ConfigServer::setServerName(
-    const ConfigServer::ServerNameType& server_name) {
+    const ConfigServer::ServerNamesType& server_name) {
   server_name_ = server_name;
 }
 

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "Log.hpp"
+#include "Utilities.hpp"
 #include "color.hpp"
 
 Parser::Parser(const std::string& filename) : tokens_() {
@@ -192,11 +193,6 @@ void Parser::parseServerName(ConfigServer&             server,
     server.addServerName(args[i]);
 }
 
-// TODO utils 함수 모으기
-bool isDigits(const std::string& str) {
-  return str.find_first_not_of("0123456789") == std::string::npos;
-}
-
 void Parser::parseListen(ConfigServer& server, const Parser::TokensType& args) {
   ConfigServer::AddressType addr = kDefaultAddress;
   ConfigServer::PortType    port = kDefaultPort;
@@ -213,7 +209,7 @@ void Parser::parseListen(ConfigServer& server, const Parser::TokensType& args) {
     } else if (args[0].find('.') != std::string::npos) {
       addr = inet_addr(args[0].c_str());
     } else {
-      if (!isDigits(args[0]))
+      if (!ft::isDigits(args[0]))
         throw std::invalid_argument(
             "Config: listen: Invalid arguments."
             "\nUsage: listen address[:port] or listen port");
@@ -229,7 +225,7 @@ void Parser::parseListen(ConfigServer& server, const Parser::TokensType& args) {
     }
 
     std::string port_str = args[0].substr(delimiter + 1);
-    if (!isDigits(port_str))
+    if (!ft::isDigits(port_str))
       throw std::invalid_argument(
           "Config: listen: Invalid arguments."
           "\nUsage: listen address[:port] or listen port");
@@ -278,7 +274,7 @@ void Parser::parseAutoindex(ConfigCommon&             common,
 
 void Parser::parseClientBodyBufferSize(ConfigCommon&             common,
                                        const Parser::TokensType& args) {
-  if (args.size() != 2 || !isDigits(args[0]))
+  if (args.size() != 2 || !ft::isDigits(args[0]))
     throw std::invalid_argument(
         "Config: client_body_buffer_size: Invalid arguments."
         "\nUsage: client_body_buffer_size size");
@@ -294,7 +290,7 @@ void Parser::parseErrorPage(ConfigCommon&             common,
 
   size_t uri_pos = args.size() - 2;
   for (size_t i = 0; i < uri_pos; i++) {
-    if (!isDigits(args[i]))
+    if (!ft::isDigits(args[i]))
       throw std::invalid_argument("Config: error_page: Invalid error code.");
     common.addErrorPage(std::make_pair(atoi(args[i].c_str()), args[uri_pos]));
   }
@@ -316,7 +312,7 @@ void Parser::parseReturn(ConfigCommon& common, const Parser::TokensType& args) {
         "Config: return: Invalid arguments."
         "\nUsage: return code url");
 
-  if (!isDigits(args[0]))
+  if (!ft::isDigits(args[0]))
     throw std::invalid_argument("Config: return: Invalid code.");
   common.setReturn(std::make_pair(atoi(args[0].c_str()), args[1]));
 }

--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -20,11 +20,7 @@ const Request& Processor::getRequest() const { return request_; }
 
 const Level& Processor::getLevel() const { return request_.getLevel(); }
 
-void Processor::setConfig(const ConfigServer& config) {
-  ft::log.writeTimeLog("[Processor] --- Set config ---");
-  config_ = config;
-  Config::printServer(config_);
-}
+void Processor::setConfig(const ConfigServer& config) { config_ = config; }
 
 void Processor::setFd(const FdType& fd) { fd_ = fd; }
 
@@ -34,7 +30,13 @@ void Processor::setStatusCode(const StatusCodeType& status_code) {
 
 void Processor::setRequest(const Request& request) { request_ = request; }
 
-void Processor::process() { (this->*method_func_map_[request_.getMethod()])(); }
+void Processor::process(const Config&                   total_config,
+                        const ConfigServer::ListenType& listen) {
+  ft::log.writeTimeLog("[Processor] --- Set config ---");
+  config_ = getConfigServerForRequest(total_config, listen);
+  Config::printServer(config_);
+  // (this->*method_func_map_[request_.getMethod()])();
+}
 
 int Processor::parseRequest(MessageType request_message) {
   try {
@@ -73,4 +75,34 @@ void Processor::initMethodFuncMap() {
   method_func_map_[kPut] = &Processor::methodPut;
   method_func_map_[kDelete] = &Processor::methodDelete;
   method_func_map_[kHead] = &Processor::methodHead;
+}
+
+ConfigServer Processor::getConfigServerForRequest(
+    const Config& total_config, const Processor::ListenType& listen) {
+  // 연결된 listen 기준으로 후보군 찾기
+  // 연결이 되어있다는 뜻은 후보가 최소 한 개 이상은 반드시 있다는 뜻
+  ServersType candidate_configs;
+
+  const ServersType servers = total_config.getServers();
+  for (ServersType::const_iterator candidate = servers.begin();
+       candidate != servers.end(); ++candidate) {
+    const ListenListType listen_list = candidate->getListen();
+    for (ListenListType::const_iterator it_listen = listen_list.begin();
+         it_listen != listen_list.end(); ++it_listen) {
+      if (*it_listen == listen)
+        candidate_configs.push_back(*candidate);
+    }
+  }
+
+  // server_name 기준으로 찾고, 없으면 첫 번째 반환
+  for (ServersType::const_iterator config = candidate_configs.begin();
+       config != candidate_configs.end(); ++config) {
+    const ServerNamesType server_name = config->getServerName();
+    for (ServerNamesType::const_iterator it_server_name = server_name.begin();
+         it_server_name != server_name.end(); ++it_server_name) {
+      if (*it_server_name == request_.getServerName())
+        return *config;
+    }
+  }
+  return candidate_configs[0];
 }

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -29,8 +29,8 @@ const RequestHeader::HeaderValueType& RequestHeader::getHeader(
 
 const RequestHeader::PortType& RequestHeader::getPort() const { return port_; }
 
-const RequestHeader::AddressType& RequestHeader::getAddress() const {
-  return address_;
+const RequestHeader::ServerNameType& RequestHeader::getServerName() const {
+  return server_name_;
 }
 
 const RequestHeader::ContentLengthType& RequestHeader::getContentLength()
@@ -64,8 +64,8 @@ void RequestHeader::setHeader(const HeaderKeyType&   key,
     (this->*parse_func_map_[key])(method, value);
 }
 
-void RequestHeader::setAddress(const AddressType& address) {
-  address_ = address;
+void RequestHeader::setServerName(const ServerNameType& server_name) {
+  server_name_ = server_name;
 }
 
 void RequestHeader::setPort(const PortType& port) { port_ = port; }
@@ -87,11 +87,11 @@ void RequestHeader::parseHost(Method method, HeaderValueType value) {
   // size_t pos;
 
   if (value.find(':') != std::string::npos) {
-    address_ = ft::splitUntilDelimiter(value, ":");
+    server_name_ = ft::splitUntilDelimiter(value, ":");
     port_ = atoi(value.c_str());
   } else {
     // TODO: 나중에 Host IP와 동일한 지 확인
-    address_ = value;
+    server_name_ = value;
     port_ = 80;
   }
 }
@@ -166,6 +166,10 @@ const Level& Request::getLevel() const { return level_; }
 
 void Request::setRequestMessage(const MessageType& request_message) {
   request_message_ = request_message;
+}
+
+const RequestHeader::ServerNameType& Request::getServerName() const {
+  return header_.getServerName();
 }
 
 void Request::setMethod(const Method& method) { method_ = method; }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -36,7 +36,7 @@ void Server::initServer() {
     throw std::runtime_error("Server: listen() error");
 }
 
-Server::FdType Server::acceptClient(const ConfigServer& config) {
+Server::FdType Server::acceptClient() {
   FdType             client_socket;
   struct sockaddr_in client_addr;
   socklen_t          client_addr_len = sizeof(client_addr);
@@ -50,10 +50,7 @@ Server::FdType Server::acceptClient(const ConfigServer& config) {
   ft::log.writeTimeLog("[Server] --- Accept client ---");
   ft::log.getLogStream() << "Host: " << socket_ << "\nClient: " << client_socket
                          << std::endl;
-
-  Processor processor;
-  processor.setConfig(config);
-  processor_map_.insert(std::make_pair(client_socket, processor));
+  processor_map_.insert(std::make_pair(client_socket, Processor()));
 
   return client_socket;
 }
@@ -103,6 +100,10 @@ void Server::closeClient(Server::FdType client_socket) {
   if (client_socket > 0)
     close(client_socket);
   processor_map_.erase(client_socket);
+}
+
+void Server::process(Server::FdType client_socket, const Config& total_config) {
+  processor_map_[client_socket].process(total_config, listen_);
 }
 
 void Server::setAddr() {

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -60,4 +60,8 @@ std::vector<std::string> splitByString(std::string str, std::string delimiter) {
   return str_vector;
 }
 
+bool isDigits(const std::string& str) {
+  return str.find_first_not_of("0123456789") == std::string::npos;
+}
+
 }  // namespace ft

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,8 +35,8 @@ int main(int argc, char* argv[]) {
   // ************************************************************************ //
 
   try {
-    Webserv webserv;
-    webserv.initWebserv(config);
+    Webserv webserv(config);
+    webserv.initWebserv();
     webserv.runWebserv();
   } catch (std::exception& e) {
     std::cerr << RED << e.what() << END << std::endl;


### PR DESCRIPTION
### 개요
1. Processor에서 필요한 ConfigServer를 찾는 시점 변경
    - 기존: accept() 이후
    - 변경: request_parsing() 이후 process() 단계
    - 검색에 필요한 total_config, listen, server_name 적절히 전달
<br>

2. find_server.conf 추가 및 검증 결과
```
(1) *:4242 - localhost
(2) *:4242 - hostA hostB hostC
(3) *:4242 - host1 host2 host3

(4) *:8080 - hospital
(5) *:8080 - localhost
```
- 4242로 접속
    - [x] localhost -> (1)
    - [x] hostB:8080 -> (2)
    - [x] host1:4242, host2 -> (3)
    - [x] host4, hostD -> (1)
-  8080로 접속
    - [x] localhost, localhost:8080, localhost:4242 -> (5)
    - [x] 127.0.0.1:8080 -> (4)

---
- closes #20 