### PR TITLE
partial send 기능 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,4 +79,6 @@ run : all
 	@./$(NAME)
 
 test : all
+	@rm -f www/put_test/file_should_exist_after www/YoupiBanane/youpi.bla
+	@touch www/YoupiBanane/youpi.bla
 	@./$(NAME) ./config/test.conf

--- a/include/Processor.hpp
+++ b/include/Processor.hpp
@@ -14,6 +14,7 @@ class Processor {
  public:
   typedef void (Processor::*MethodFuncType)();
   typedef std::map<Method, MethodFuncType> MethodFuncMapType;
+  typedef ssize_t                          OffsetType;
 
   typedef Config::ServersType      ServersType;
   typedef Config::ServerNamesType  ServerNamesType;
@@ -42,12 +43,14 @@ class Processor {
   const StatusCodeType& getStatusCode() const;
   const Request&        getRequest() const;
   const Level&          getLevel() const;
+  const OffsetType&     getOffset() const;
   // const Response& getResponse() const;
 
   const ResponseMessageType& getResponseMessage() const;
 
   void setStatusCode(const StatusCodeType& status_code);
   void setRequest(const Request& request);
+  void setOffset(const OffsetType& offset);
 
   void process(const Config& total_config, const ListenType& listen);
 
@@ -68,6 +71,7 @@ class Processor {
  private:
   MethodFuncMapType method_func_map_;
 
+  OffsetType     offset_;
   ConfigLocation config_;
   FileManager    file_manager_;
   StatusCodeType status_code_;

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -16,7 +16,8 @@ enum RecvState {
   kRecvError = -1,
   kParseError = -2
 };
-enum SendState { kSendError = -1, kSendSuccess = 0 };
+
+enum SendState { kSendError = -1, kSendSuccess = 0, kSendContinuous = 1 };
 
 class Server {
  public:

--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -7,10 +7,11 @@
 #include <string>
 #include <vector>
 
+#include "CgiHandler.hpp"
 #include "Config.hpp"
 #include "Log.hpp"
 
-Processor::Processor() : status_code_(200) { initMethodFuncMap(); }
+Processor::Processor() : offset_(0), status_code_(200) { initMethodFuncMap(); }
 
 Processor::~Processor() {}
 
@@ -24,10 +25,14 @@ const Processor::ResponseMessageType& Processor::getResponseMessage() const {
 }
 const Level& Processor::getLevel() const { return request_.getLevel(); }
 
+const Processor::OffsetType& Processor::getOffset() const { return offset_; }
+
 void Processor::setStatusCode(const StatusCodeType& status_code) {
   status_code_ = status_code;
 }
 void Processor::setRequest(const Request& request) { request_ = request; }
+
+void Processor::setOffset(const OffsetType& offset) { offset_ = offset; }
 
 void Processor::process(const Config&                   total_config,
                         const ConfigServer::ListenType& listen) {

--- a/src/Webserv.cpp
+++ b/src/Webserv.cpp
@@ -129,8 +129,10 @@ void Webserv::sendResponse(int& state, fd_set& write_fds) {
         FD_CLR(*it, &fd_set_);
         FD_CLR(*it, &write_fds);
         connect_socket_.erase(*it);
+        ready_to_write_.erase(it);
+      } else if (send_state == kSendSuccess) {
+        ready_to_write_.erase(it);
       }
-      ready_to_write_.erase(it);
       state = 0;
       break;
     }


### PR DESCRIPTION
### 개요
기존: 보낼 response 문자열을 한 번만 send하고 더이상 보내지 않음
변경: send()의 반환값을 통해 해당 문자열 길이와 일치하지 않으면 kSendContinuous를 반환
    - 다음 send() 때는 offset 만큼 뒤에서 보내고, 길이가 일치할 때까지 반복
    - 일치하면 그 때 ready_to_write_에서 삭제

---
- closes #43 